### PR TITLE
Wire the Playwright e2e suite into CI (#26)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,95 @@
+name: e2e
+
+# The Playwright browser suite. Deliberately NOT part of test.yml, whose
+# contract is "fast, hermetic, per-push" — this one builds the app, boots a
+# real `next start` and drives Chromium, which is minutes rather than seconds.
+#
+# `pull_request` only, never `push`: on a PR branch both triggers fire and the
+# suite would run twice for one change. `workflow_dispatch` is the pre-deploy
+# ritual — given ~5 visitors/day and a deploy-to-prod-to-test workflow, that is
+# arguably the more valuable of the two.
+#
+# This job is intended to REPORT, not to gate. `main` currently has no branch
+# protection at all, so that holds trivially — but note the corollary: promoting
+# this to a required check later means creating a ruleset from scratch, not
+# flipping a toggle on an existing one.
+#
+# `workflow_dispatch` is not dispatchable until this file is on the default
+# branch, so the pre-deploy-ritual half stays inert until this branch merges.
+#
+# Same architecture caveat as test.yml: this runs on x86_64 while production is
+# ARM64 (Oracle A1 Flex), and better-sqlite3 is a native module.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+# A rapid series of pushes to a PR should not stack runs of a minutes-long job.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    # playwright.config.ts gives `next start` 60s to boot, but a run that hangs
+    # after boot has no ceiling of its own. See §3 item 7 of
+    # docs/handoffs/260803-playwright-e2e.md — an orphaned server on port 3100
+    # is a known unguarded failure mode locally too.
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      # `ci`, not `install`, for the same reason as test.yml: the lockfile is
+      # the source of truth for deployments.
+      - run: npm ci
+
+      # Only Chromium — playwright.config.ts has exactly one non-canary project
+      # (Desktop Chrome). Uncached on purpose: ~40s against a job that already
+      # spends longer than that on the build, and a browser cache keyed on the
+      # wrong thing yields a Chromium that does not match the driver.
+      - run: npx playwright install --with-deps chromium
+
+      # lint and `tsc --noEmit` are NOT repeated here — test.yml already runs
+      # both on pull_request. A red job here therefore means a browser flow
+      # broke, unambiguously.
+
+      # A separate step from the test run so a build failure reads as a build
+      # failure rather than as a server that failed to start.
+      - name: Build
+        run: npm run next-build
+        env:
+          # Next inlines NEXT_PUBLIC_* at BUILD time, so this has to be here and
+          # not on the test step. Without it the two client-write specs fail
+          # before making a request: getPublicApiKey()
+          # (src/lib/bungie/client-api.ts) throws on a missing key, and there is
+          # no .env on a runner.
+          #
+          # A fake value is correct. Every bungie.net request is answered by the
+          # page.route interceptor in e2e/support/test-fixtures.ts and never
+          # leaves the process, so only non-emptiness is load-bearing — which is
+          # also why this literal matching package.json's `e2e` script is a
+          # convenience, not a constraint. Tests that genuinely reach Bungie are
+          # tagged @live and excluded by grepInvert (issue #25).
+          NEXT_PUBLIC_BUNGIE_PUBLIC_API_KEY: e2e-not-a-real-bungie-key
+
+      # `npx playwright test`, not `npm run e2e` — that script rebuilds, and the
+      # build already happened above.
+      - name: Run Playwright
+        run: npx playwright test
+
+      # trace: 'on-first-retry' plus retries: 2 in CI means a failure that
+      # survives its retries has left a trace behind. Without this upload it is
+      # discarded with the runner.
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-results
+          path: test-results/
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Port and build-lock hygiene is enforced by hooks in `.claude/hooks/` — a dev s
 
 - `npm run start` — **web app only.** The crawler/scanner/discovery are separate PM2 processes (`ecosystem.config.js`) and must be started independently.
 - `npm run setup-manifest` — writes `data/manifest-cache.json` for a human to read. Changes nothing about runtime behaviour; see the raid-detection convention below.
-- `npm run e2e` — Playwright browser tests. Builds, then serves the app on **port 3100** against a throwaway seeded database. Not in `npm test`, not in CI. `npm run e2e:nobuild` skips the build for fast iteration and is wrong if `.next` is stale.
+- `npm run e2e` — Playwright browser tests. Builds, then serves the app on **port 3100** against a throwaway seeded database. Not in `npm test`; runs in CI via its own `e2e.yml` on `pull_request` + `workflow_dispatch`, never on `push`. The script pins a dummy `NEXT_PUBLIC_BUNGIE_PUBLIC_API_KEY` into the build — Next inlines `NEXT_PUBLIC_*` at build time, and the client-write specs throw on a missing key before the Bungie stub can fire. `npm run e2e:nobuild` skips the build for fast iteration, is wrong if `.next` is stale, and inherits whatever key the last build baked in.
 - `npm run e2e:maintenance` — slow, spawns real crawler/scanner processes against a mock Bungie server. Deliberately outside `npm test` and CI. Unrelated to `npm run e2e` despite the name.
 
 Scripts run via `tsx` using `tsconfig.scripts.json`. Next.js app and scripts compile separately.
@@ -80,7 +80,7 @@ There is **no continuous replication.** Backups are manual snapshots: `npx tsx s
 
 ## Testing
 
-Vitest. **`tests/README.md` is the how-to** — read it before writing or changing a test; it covers the two ground rules (mock `fetch` and only `fetch`; `npm test` stays hermetic), the layout, colocate-vs-`tests/`, fixtures-vs-builders, and the naming conventions. The rationale is in [ADR 0003](docs/adr/0003-tests-run-against-a-real-sqlite-file.md) and [ADR 0004](docs/adr/0004-mock-only-at-the-network-boundary.md); the build-out is in `docs/handoffs/testing-framework-handoff.md`. CI runs `npm test` only.
+Vitest. **`tests/README.md` is the how-to** — read it before writing or changing a test; it covers the two ground rules (mock `fetch` and only `fetch`; `npm test` stays hermetic), the layout, colocate-vs-`tests/`, fixtures-vs-builders, and the naming conventions. The rationale is in [ADR 0003](docs/adr/0003-tests-run-against-a-real-sqlite-file.md) and [ADR 0004](docs/adr/0004-mock-only-at-the-network-boundary.md); the build-out is in `docs/handoffs/testing-framework-handoff.md`. CI runs `npm test` (plus lint and `tsc`) on every push and PR via `test.yml`; the browser suite has its own `e2e.yml` on `pull_request` and manual dispatch only.
 
 **Never reorder `setupFiles` in `vitest.config.ts`** — `tests/setup/test-db-path.ts` must stay first or the suite binds to the live dev database and `resetTestDb()` deletes from it. `getDb()` enforces this; `tests/README.md` explains why.
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "e2e": "npm run next-build && playwright test",
+    "e2e": "NEXT_PUBLIC_BUNGIE_PUBLIC_API_KEY=e2e-not-a-real-bungie-key npm run next-build && playwright test",
     "e2e:nobuild": "playwright test",
     "e2e:maintenance": "npx tsx scripts/test-maintenance-cycle.ts",
     "capture-fixtures": "npx tsx scripts/capture-pgcr-fixture.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,8 +51,24 @@ export default defineConfig({
     // order-dependent flake. See the plan's D2.
     fullyParallel: false,
     workers: 1,
-    retries: 0,
+
+    // Two retries in CI, none locally. `trace: 'on-first-retry'` below means the
+    // retry is what *produces* the diagnostic, so this and the artifact upload in
+    // .github/workflows/e2e.yml are one decision. Known cost: a genuinely flaky
+    // test goes green on retry and is silent unless you read the run summary.
+    // Note this covers the `canary` project below as well, so a failure of the
+    // fixture-database guard is also retried twice before it reports. That is
+    // survivable — the canary is deterministic, so retries cannot turn a real
+    // failure green — but it is not purely diagnostic the way a spec retry is.
+    retries: process.env.CI ? 2 : 0,
     forbidOnly: !!process.env.CI,
+
+    // `@live` tests reach the real Bungie API (see issue #25). Excluded from every
+    // invocation by default — here rather than in the CI command, so landing the
+    // first @live spec cannot start making network calls from a GitHub runner and
+    // does not require touching the workflow. Run them with
+    // `npx playwright test --grep @live`.
+    grepInvert: /@live/,
 
     reporter: 'list',
 
@@ -105,10 +121,16 @@ export default defineConfig({
             // NEXT_PUBLIC_BUNGIE_PUBLIC_API_KEY is deliberately NOT set here, and
             // cannot usefully be: Next inlines NEXT_PUBLIC_* at *build* time, so a
             // value supplied to `next start` never reaches the client bundle. The
-            // browser gets whatever was in .env when `next build` ran. Harmless
-            // today — no baseline spec makes a browser → Bungie call, and
-            // e2e/support/test-fixtures.ts stubs bungie.net regardless — but worth
-            // knowing before writing a spec that depends on the key's value.
+            // browser gets whatever was in .env when `next build` ran.
+            //
+            // That is NOT harmless: getPublicApiKey() (src/lib/bungie/client-api.ts)
+            // throws on a missing key before fetch, so the client-write specs fail
+            // before the bungie.net stub can fire — which is what happens on a fresh
+            // clone or in CI, where there is no .env. The key is therefore pinned
+            // where it can actually reach the bundle: an env prefix on `npm run e2e`
+            // in package.json, and `env:` on the build step in
+            // .github/workflows/e2e.yml. `e2e:nobuild` does not rebuild and so
+            // inherits whatever the last build baked in.
 
             // ACTIVE_SESSION_DISPLAY_LIMIT is deliberately NOT overridden here.
             // src/app/active-sessions/page.tsx requests `?limit=600` as a

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,6 +19,13 @@ npm run e2e           # build, then drive Chromium
 npm run e2e:nobuild   # skip the build (fast; wrong if .next is stale)
 ```
 
+`npm run e2e` pins a dummy `NEXT_PUBLIC_BUNGIE_PUBLIC_API_KEY` into the build. Next inlines
+`NEXT_PUBLIC_*` at *build* time, so it has to be on `next-build` and cannot be set from
+`playwright.config.ts`; without it `getPublicApiKey()` throws before the Bungie stub fires and
+the client-write specs fail on a fresh clone or in CI. A fake value is correct — every
+bungie.net request is answered by the interceptor in `e2e/support/test-fixtures.ts`. Because
+`e2e:nobuild` does not rebuild, it inherits whatever key the last build baked in.
+
 `npm test` is meant to stay fast and reachable from anywhere. It never touches the network and
 never touches the real database — if it ever does either, that's a bug in the test, not a
 tolerable shortcut.
@@ -33,7 +40,7 @@ Three different things that all deserve to exist.
 | What | Unit and query-level tests | The app in a real browser | The maintenance-cycle harness |
 | Speed | Under a second | ~10s plus a Next build | Minutes |
 | Needs | Nothing | Chromium; builds and serves the app on port 3100 | Spawns real crawler/scanner processes against a mock Bungie server |
-| In CI | Yes | Not yet — see `docs/handoffs/260803-playwright-e2e.md` | No — too slow, too many moving parts |
+| In CI | Yes — `test.yml`, every push and PR | Yes — its own `e2e.yml`, `pull_request` + manual only | No — too slow, too many moving parts |
 
 **File naming is what keeps the two test runners apart.** `.test.ts` is Vitest;
 `.spec.ts` under `e2e/` is Playwright. Vitest's `include` lists its own


### PR DESCRIPTION
closes #26 
A separate e2e.yml on pull_request + workflow_dispatch, never push — on a PR branch both fire and the suite would run twice for one change. Deliberately not added to test.yml, whose contract is "fast, hermetic, per-push". Intended to report, not to gate: main has no branch protection at all today, and promoting this to a required check later means creating a ruleset, not flipping a toggle.

Landed ahead of #25 (@live contract tests), which is not a prerequisite. No @live spec exists, so there was nothing for CI to trip over. The only real coupling — #25's design grep-inverts @live out of the default run — is closed here by putting grepInvert: /@live/ in playwright.config.ts rather than in the CI command. The exclusion now holds for every invocation, so landing the first @live spec cannot start making network calls from a GitHub runner and needs no change to the workflow.

The one thing the deferred design in the handoff did not anticipate: NEXT_PUBLIC_BUNGIE_PUBLIC_API_KEY has to be set at BUILD time or the two client-write specs fail for a reason unrelated to the code under test. getPublicApiKey() (src/lib/bungie/client-api.ts:69) throws on a missing key before fetch, so the Bungie stub never fires — and there is no .env on a runner or in a fresh clone.

It could not be fixed the way PAGE_TOKEN_SECRET was. Next inlines NEXT_PUBLIC_* at build time and `npm run e2e` is `next-build && playwright test`, so the build finishes before Playwright's config loads; a constant in fixture-db.ts would be set too late to reach the bundle. Hence an env prefix on the e2e script itself, plus env: on the workflow's build step.

Pinned unconditionally rather than ${VAR:-default}: a conditional pin is the exact shape that hid the PAGE_TOKEN_SECRET bug, where a machine with a real key in .env tests a different configuration than CI does. A fake value is correct — every bungie.net request is answered by the page.route('**/*') interceptor in e2e/support/test-fixtures.ts, which fulfills from the runner process and never opens a socket, so only non-emptiness is load-bearing.

Verified by mutation, not by reasoning. After npm run e2e the literal is present in .next/static/chunks/, proving the prefix overrides .env. Building with the key explicitly empty and re-running the dependent specs fails exactly 3 tests — client-write-verify x2 and client-write-resolve x1, the specs whose docblocks predicted it — with the canary passing.

retries: process.env.CI ? 2 : 0 with test-results/ uploaded on failure. One decision, not two: trace: 'on-first-retry' means the retry is what produces the diagnostic. Known cost: a flaky test goes green on retry and is silent unless someone reads the run summary. Note it covers the canary project too.

Also corrects three docs that this change made self-contradicting: CLAUDE.md still said "CI runs npm test only", the runner table in tests/README.md still said e2e was "not yet" in CI, and the webServer.env comment in playwright.config.ts still claimed a missing public key was "harmless today — no baseline spec makes a browser → Bungie call", which is precisely what this change refutes.

No ADR: deleting a workflow file is a one-line PR, so it fails the hard-to-reverse test. Decision record is a comment on #26, with notes on #25 (grepInvert) and #27 (the Sentry volume argument now that every PR emits).

Verified: lint clean, tsc --noEmit clean, npm test 248 passed, npm run e2e 26 passed.